### PR TITLE
ci: Update macOS code signing and notarization step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,8 @@ jobs:
           MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.MACOS_NOTARIZATION_TEAM_ID }}
           MACOS_NOTARIZATION_PWD: ${{ secrets.MACOS_NOTARIZATION_PWD }}
         run: |
+          cp .env.ci .env
+          # NOTE: Comment out or remove the following commands to disable code signing and notarization
           # Decode certificate
           echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
           # Create keychain
@@ -64,7 +66,6 @@ jobs:
           # Create keychain profile
           xcrun notarytool store-credentials "notarytool-profile" --apple-id "$MACOS_NOTARIZATION_APPLE_ID" --team-id "$MACOS_NOTARIZATION_TEAM_ID" --password "$MACOS_NOTARIZATION_PWD"
           # Store info in environment file
-          cp .env.ci .env
           echo 'CERT="'$MACOS_CERTIFICATE_NAME'"' >> .env
           echo 'KEYC=notarytool-profile' >> .env
       - name: Build package
@@ -96,6 +97,8 @@ jobs:
           MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.MACOS_NOTARIZATION_TEAM_ID }}
           MACOS_NOTARIZATION_PWD: ${{ secrets.MACOS_NOTARIZATION_PWD }}
         run: |
+          cp .env.ci .env
+          # NOTE: Comment out or remove the following commands to disable code signing and notarization
           # Decode certificate
           echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
           # Create keychain
@@ -107,7 +110,6 @@ jobs:
           # Create keychain profile
           xcrun notarytool store-credentials "notarytool-profile" --apple-id "$MACOS_NOTARIZATION_APPLE_ID" --team-id "$MACOS_NOTARIZATION_TEAM_ID" --password "$MACOS_NOTARIZATION_PWD"
           # Store info in environment file
-          cp .env.ci .env
           echo 'CERT="'$MACOS_CERTIFICATE_NAME'"' >> .env
           echo 'KEYC=notarytool-profile' >> .env
       - name: Build package


### PR DESCRIPTION
Make it more clear that the user can comment out certain lines to disable code signing and notarization.